### PR TITLE
fix: resolve 6 bugs found in codebase audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ If you need options, `criticalCSS` supports the following config options:
 criticalCSS({
   /** Silence log output (plugin specific, everything else is for criticalCSS) */
   silent: boolean,
-  /** glob pattern to match html files, use this to selectively pick html files into which critical css will be inlined (ex: just the home page excluding nested pages).
-   * By default, all html files in the dist directory will be inlined.
+  /** Glob pattern to match HTML files. Use this to selectively pick HTML files
+   * for critical CSS inlining (e.g., just the home page excluding nested pages).
+   * By default, all HTML files in the dist directory will be inlined.
    */
-  htmlPathRegex: string,
+  htmlPathGlob: string,
   /* HTML source to operate against */
   html: string,
   /* Array of CSS file paths, file globs, Vinyl objects, or source CSS strings */

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
   output: 'static',
   integrations: [criticalCSS({
     // silent: true,
-    // htmlPathRegex: "**/test.html",
+    // htmlPathGlob: "**/test.html",
     height: 1080,
     width: 1920,
   })],

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,8 +15,13 @@ export type PluginOptions = Omit<
 > & {
   /** silence console output */
   silent?: boolean;
-  /** glob pattern to match html files, use this to selectively pick html files into which critical css will be inlined (ex: just the home page excluding nested pages).
-   * By default, all html files in the dist directory will be inlined.
+  /** Glob pattern to match HTML files. Use this to selectively pick HTML files
+   * for critical CSS inlining (e.g., just the home page excluding nested pages).
+   * By default, all HTML files in the dist directory will be inlined.
+   */
+  htmlPathGlob?: string;
+  /**
+   * @deprecated Use `htmlPathGlob` instead. This option accepts a glob pattern, not a regex.
    */
   htmlPathRegex?: string;
 };
@@ -24,9 +29,19 @@ export type PluginOptions = Omit<
 export default (pluginOptions: Partial<PluginOptions> | undefined = {}): AstroIntegration => {
   const {
     silent,
-    htmlPathRegex = "**/*.html",
+    htmlPathGlob,
+    htmlPathRegex,
     ...options
   } = pluginOptions;
+
+  const htmlGlobPattern = htmlPathGlob ?? htmlPathRegex ?? "**/*.html";
+
+  if (htmlPathRegex !== undefined) {
+    log("⚠️ 'htmlPathRegex' is deprecated. Use 'htmlPathGlob' instead.");
+    if (!silent) {
+      console.warn("astro-critical-css: 'htmlPathRegex' is deprecated. Use 'htmlPathGlob' instead.");
+    }
+  }
   log("Options: %o", options);
   return {
     name: "critical-css",
@@ -36,7 +51,7 @@ export default (pluginOptions: Partial<PluginOptions> | undefined = {}): AstroIn
         let htmlOutputSize = 0;
         let fileCount = 0;
         const distPath = fileURLToPath(dir);
-        const htmlPathsStream = fg.stream(htmlPathRegex, { cwd: distPath });
+        const htmlPathsStream = fg.stream(htmlGlobPattern, { cwd: distPath });
         const startTime = Date.now();
         log("🪄 Starting: Inlining CSS in path %s", distPath);
         for await (const htmlPath of htmlPathsStream) {
@@ -55,7 +70,14 @@ export default (pluginOptions: Partial<PluginOptions> | undefined = {}): AstroIn
 
           checkError(results);
 
-          let html = "html" in results ? results.html : "";
+          const html = "html" in results ? (results as { html: string }).html : "";
+
+          if (!html) {
+            log("Skipping write for %s: empty HTML result", htmlFilePath);
+            if (!silent) console.warn("⚠️ Skipping write for", htmlFilePath, "- empty HTML result");
+            continue;
+          }
+
           const htmlData = Buffer.from(html, "utf-8");
           htmlOutputSize += htmlData.length;
           log(
@@ -87,9 +109,12 @@ export default (pluginOptions: Partial<PluginOptions> | undefined = {}): AstroIn
 
 function checkError(results: unknown) {
   if (results && typeof results === "object" && "error" in results) {
-    console.error("Error inlining CSS:", results?.error);
-    log("Error inlining CSS: %o", results?.error);
-    throw results.error;
+    const error = (results as Record<string, unknown>).error;
+    console.error("Error inlining CSS:", error);
+    log("Error inlining CSS: %o", error);
+    throw error instanceof Error
+      ? error
+      : new Error(String(error ?? "Unknown critical CSS error"));
   }
 }
 
@@ -101,7 +126,6 @@ function logSummary(htmlInputSize: number, htmlOutputSize: number, startTime: nu
     "HTML difference in bytes +/-: %s",
     (htmlOutputSize - htmlInputSize).toLocaleString()
   );
-  log("✅ Done: Inlining CSS in %d sec.", endTime - startTime);
-  return endTime;
+  log("✅ Done: Inlining CSS in %d sec.", (endTime - startTime) / 1000);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "astro-critical-css",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-critical-css",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "astro": "^5.0.4",
         "critical": "^7.2.1",
-        "debug": "^4.4.0"
+        "debug": "^4.4.0",
+        "fast-glob": "^3.3.2"
       },
       "devDependencies": {
-        "fast-glob": "^3.3.2",
         "tsup": "^8.3.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "dependencies": {
     "astro": "^5.0.4",
     "critical": "^7.2.1",
-    "debug": "^4.4.0"
+    "debug": "^4.4.0",
+    "fast-glob": "^3.3.2"
   },
   "devDependencies": {
-    "fast-glob": "^3.3.2",
     "tsup": "^8.3.5"
   },
   "keywords": [


### PR DESCRIPTION
- Move fast-glob from devDependencies to dependencies (was causing
  MODULE_NOT_FOUND at runtime for users)
- Guard against overwriting HTML files with empty string when
  critical.generate() returns empty html result
- Fix logSummary logging milliseconds as seconds (missing /1000)
  and remove unused return value
- Fix checkError to always throw proper Error instances instead of
  potentially throwing undefined/string values
- Rename misleading htmlPathRegex option to htmlPathGlob (it accepts
  glob patterns, not regex) with backward-compatible deprecation alias
- Delete dead empty file lib/critical-type.ts

https://claude.ai/code/session_01UpR1bY7N7ia4Xbe5Vx622U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `htmlPathGlob` option for specifying which HTML files to inline critical CSS.

* **Bug Fixes**
  * Improved error handling with proper error normalization.
  * Enhanced timing logs to report elapsed time in seconds.

* **Deprecation**
  * `htmlPathRegex` option deprecated; migrate to `htmlPathGlob` with runtime warnings provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->